### PR TITLE
Expose .clear() on TextInput

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -174,6 +174,9 @@ class RCTKeyboardToolbarTextInput extends React.Component {
     focus() {
         this.refs.input.focus();
     }
+    clear() {
+        this.refs.input.clear();
+    }
     render() {
         return (<TextInput {...this.props} ref="input"/>);
     }


### PR DESCRIPTION
Consumers are now able to clear the content of the wrapped `<TextInput />`.

Thanks for reviewing!