### PR TITLE
Fix the broken setPickerRowByIndex method

### DIFF
--- a/RCTTextInputUtils/RCTKeyboardToolbar.m
+++ b/RCTTextInputUtils/RCTKeyboardToolbar.m
@@ -197,12 +197,21 @@ RCT_EXPORT_METHOD(setPickerRowByIndex:(nonnull NSNumber *)reactNode
             return;
         }
         
-        UIPickerView *pickerView = ((UIPickerView *)view.inputView);
+        UITextField *textView;
+        if ([view class] == [RCTTextView class]) {
+            RCTTextView *reactNativeTextView = ((RCTTextView *)view);
+            textView = [reactNativeTextView getTextView];
+        }
+        else {
+            RCTTextField *reactNativeTextView = ((RCTTextField *)view);
+            textView = [reactNativeTextView textField];
+        }
         
-        NSInteger *index = [RCTConvert NSInteger:options[@"index"]];
+        UIPickerView *pickerView = ((UIPickerView *)textView.inputView);
+        
+        NSInteger index = [RCTConvert NSInteger:options[@"index"]];
         
         [pickerView selectRow: index inComponent:0 animated:YES];
-        
     }];
 }
 

--- a/RCTTextInputUtils/RCTKeyboardToolbar.m
+++ b/RCTTextInputUtils/RCTKeyboardToolbar.m
@@ -52,7 +52,7 @@ RCT_EXPORT_METHOD(configure:(nonnull NSNumber *)reactNode
         }
         else {
             RCTTextField *reactNativeTextView = ((RCTTextField *)view);
-            textView = reactNativeTextView;
+            textView = [reactNativeTextView textField];
         }
         
         if (options[@"tintColor"]) {
@@ -139,8 +139,8 @@ RCT_EXPORT_METHOD(moveCursorToLast:(nonnull NSNumber *)reactNode) {
         RCTTextField *textView = ((RCTTextField *)view);
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            UITextPosition *position = [textView endOfDocument];
-            textView.selectedTextRange = [textView textRangeFromPosition:position toPosition:position];
+            UITextPosition *position = [textView.backedTextInputView endOfDocument];
+            textView.backedTextInputView.selectedTextRange = [textView.backedTextInputView textRangeFromPosition:position toPosition:position];
         });
     }];
 }
@@ -162,9 +162,9 @@ RCT_EXPORT_METHOD(setSelectedTextRange:(nonnull NSNumber *)reactNode
         NSRange range  = NSMakeRange([startPosition integerValue], [endPosition integerValue]);
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            UITextPosition *from = [textView positionFromPosition:[textView beginningOfDocument] offset:range.location];
-            UITextPosition *to = [textView positionFromPosition:from offset:range.length];
-            [textView setSelectedTextRange:[textView textRangeFromPosition:from toPosition:to]];
+            UITextPosition *from = [textView.backedTextInputView positionFromPosition:[textView.backedTextInputView beginningOfDocument] offset:range.location];
+            UITextPosition *to = [textView.backedTextInputView positionFromPosition:from offset:range.length];
+            [textView.backedTextInputView setSelectedTextRange:[textView.backedTextInputView textRangeFromPosition:from toPosition:to]];
         });
     }];
 }

--- a/RCTTextInputUtils/RCTTextFieldExtension.m
+++ b/RCTTextInputUtils/RCTTextFieldExtension.m
@@ -12,11 +12,15 @@
 
 - (void)setSelectedRange:(NSRange)range
 {
-    UITextPosition* beginning = self.beginningOfDocument;
-    UITextPosition* startPosition = [self positionFromPosition:beginning offset:range.location];
-    UITextPosition* endPosition = [self positionFromPosition:beginning offset:range.location + range.length];
-    UITextRange* selectionRange = [self textRangeFromPosition:startPosition toPosition:endPosition];
-    [self setSelectedTextRange:selectionRange];
+    UITextPosition* beginning = self.backedTextInputView.beginningOfDocument;
+    UITextPosition* startPosition = [self.backedTextInputView positionFromPosition:beginning offset:range.location];
+    UITextPosition* endPosition = [self.backedTextInputView positionFromPosition:beginning offset:range.location + range.length];
+    UITextRange* selectionRange = [self.backedTextInputView textRangeFromPosition:startPosition toPosition:endPosition];
+    [self.backedTextInputView setSelectedTextRange:selectionRange];
+}
+
+- (void)invalidateInputAccessoryView {
+    // prevents input accessory being removed
 }
 
 @end

--- a/RCTTextInputUtils/RCTTextViewExtension.m
+++ b/RCTTextInputUtils/RCTTextViewExtension.m
@@ -16,4 +16,8 @@
     return [self valueForKey:@"_textView"];
 }
 
+- (void)invalidateInputAccessoryView {
+    // prevents input accessory being removed
+}
+
 @end

--- a/index.ios.js
+++ b/index.ios.js
@@ -4,7 +4,7 @@ const React = require('react');
 
 const {findNodeHandle, TextInput, NativeAppEventEmitter, NativeModules: {
         KeyboardToolbar
-    }, processColor} = require('react-native');
+    }, processColor, Keyboard} = require('react-native');
 
 class RCTKeyboardToolbarHelper {
     static sharedInstance = new RCTKeyboardToolbarHelper();
@@ -77,8 +77,9 @@ class RCTKeyboardToolbarManager {
         });
     }
     static dismissKeyboard(node) {
-        var nodeHandle = findNodeHandle(node);
-        KeyboardToolbar.dismissKeyboard(nodeHandle);
+        // var nodeHandle = findNodeHandle(node);
+        // KeyboardToolbar.dismissKeyboard(nodeHandle);
+		Keyboard.dismiss();
     }
     static moveCursorToLast(node) {
         var nodeHandle = findNodeHandle(node);


### PR DESCRIPTION
After did some digging, we found out that the setPickerRowByIndex was not functioning as it was suppose to, even though passing in the correct index, the picker is still showing the first value of the dataset. This is a fix to address the issue